### PR TITLE
sort input files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MANDIR=/usr/share/man
 FLAGS=$(CFLAGS) -g3 -std=gnu9x -Wall -Wshadow -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes -I${INCLUDEDIR}
 VERSION=$(shell grep "\#define EBISO_VERSION" ${INCLUDEDIR}/${PROGNAME}.h | awk '{ print $$NF }' | sed s/\"//g)
 
-SRC=$(wildcard ${LIBDIR}/*.c)
+SRC=$(sort $(wildcard ${LIBDIR}/*.c))
 HEADERS=$(wildcard ${INCLUDEDIR}/*.h)
 OBJ=$(addprefix ${LIBDIR}/,$(notdir $(SRC:.c=.o)))
 


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would differ.

See https://reproducible-builds.org/ for why this matters.